### PR TITLE
Update README.md to fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Given, When, Then drops a flat sequence structure with four frames designed to m
 * Then: Where you perform your comparisons and check your results.
 * Clean Up: A convenient place to close references etc. without interfering with the VI Tester error chain.
 
-Learn more at [https://devs.wiresmithtech.com/blog/given-when-then/](https://devs.wiresmithtech.com/blog/given-when-then/)
+Learn more at [https://www.wiresmithtech.com/devs/given-when-then/](https://www.wiresmithtech.com/devs/given-when-then/)
 
 ![given when then complex example](docs/images/givenwhenthencomplexexample.png?raw=true)
 
@@ -111,7 +111,7 @@ This is a template for testing that an event has fired. You should drop it into 
 
 ![dynamic event test template](docs/images/dynamiceventtestvitester.png?raw=true)
 
-Learn more at [https://devs.wiresmithtech.com/blog/testing-events-vi-tester/]( https://devs.wiresmithtech.com/blog/testing-events-vi-tester/)
+Learn more at [https://www.wiresmithtech.com/devs/testing-events-vi-tester/](https://www.wiresmithtech.com/devs/testing-events-vi-tester/)
 
 ### Usage Examples ###
 


### PR DESCRIPTION
Updated links to point to https://www.wiresmithtech.com/devs

instead of https://devs.wiresmithtech.com/blog that no longer exists